### PR TITLE
Potential fix for code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/dotnet-app/Controllers/TasksController.cs
+++ b/dotnet-app/Controllers/TasksController.cs
@@ -71,7 +71,8 @@ public class TasksController : ControllerBase
     [ProduceResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<TaskItem>> CreateTask(TaskItem task)
     {
-        _logger.LogInformation("Creating new task: {Title}", task.Title);
+        var safeTitleForLog = task.Title?.Replace("\r", "").Replace("\n", "");
+        _logger.LogInformation("Creating new task: {Title}", safeTitleForLog);
 
         if (string.IsNullOrWhiteSpace(task.Title))
         {


### PR DESCRIPTION
Potential fix for [https://github.com/rpatel765-git/SampleApp/security/code-scanning/1](https://github.com/rpatel765-git/SampleApp/security/code-scanning/1)

To fix this without changing functionality, sanitize `task.Title` only for logging by removing newline/control characters that can forge log entries, while keeping the original `task.Title` unchanged for business logic and persistence.

Best fix in this file:
- In `dotnet-app/Controllers/TasksController.cs`, inside `CreateTask`, replace the direct logging of `task.Title` with a sanitized local variable (for example: remove `\r` and `\n`, and safely handle null).
- Keep all existing logic intact (validation, DB save, response).
- No new dependencies are required; use built-in `string.Replace`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
